### PR TITLE
chore(pom.xml): update plugin versions and add new dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,9 +271,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>${maven-release-plugin.version}</version>
-                <configuration>
-                    <scmCommentPrefix>[Version Bumped to ${project.version}]</scmCommentPrefix>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
- Update the version of the `assertj` plugin to `3.24.2`
- Update the version of the `build-helper-maven-plugin` to `3.2.0`
- Update the version of the `copy-rename-maven-plugin` to `1.0.1`
- Update the version of the `gmavenplus-plugin` to `3.0.0`
- Update the version of the `groovy-all` plugin to `3.0.19`
- Update the version of the `hamcrest` plugin to `1.3`
- Update the version of the `jackson-core` plugin to `2.15.2`
- Update the version of the `jacoco-maven-plugin` to `0.8.10`
- Update the version of the `junit-jupiter` plugin to `5.10.0`
- Update the version of the `jsonassert` plugin to `1.5.1`
- Update the version of the `lombok` plugin to `1.18.28`
- Update the version of the `maven-compiler-plugin` to `3.11.0`
- Update the version of the `maven-release-plugin` to `3.0.1`
- Update the version of the `maven-shade-plugin` to `3.5.0`
- Update the version of the `maven-surefire-plugin` to `3.1.2`
- Update the version of the `maven-source-plugin` to `3.3.0`
- Update the version of the `maven-javadoc-plugin` to `3.5.0`
- Update the version of the `maven-jar-plugin` to `3.3.0`
- Update the version of the `nexus-staging-maven-plugin` to `1.6.13`
- Update the version of the `org-json` plugin to `20230618`
- Update the version of the `maven-resources-plugin` to `3.3.1`
- Update the version of the `mockito-core` plugin to `4.11.0`
- Update the version of the `mockito-junit-jupiter` plugin to `4.8.0`
- Update the version of the `snakeyaml` plugin to `2.2` -