### PR TITLE
chore(pom.xml): remove maven-assembly-plugin configuration and execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -693,34 +693,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <version>${maven-assembly-plugin.version}</version>
-                        <configuration>
-                            <archive>
-                                <manifestEntries>
-                                    <Implementation-Title>${project.name}</Implementation-Title>
-                                    <Bundle-Vendor>Liquibase</Bundle-Vendor>
-                                    <Bundle-Version>${project.version}</Bundle-Version>
-                                </manifestEntries>
-                            </archive>
-                            <appendAssemblyId>false</appendAssemblyId>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                            <finalName>${project.name}-${project.version}</finalName>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>assemble-all</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
The maven-assembly-plugin configuration and execution were removed from the pom.xml file. This plugin was previously used to create an assembly with dependencies, but it is no longer needed for the project. Removing this configuration simplifies the build process and reduces unnecessary complexity.