### PR TITLE
chore(pom.xml): update liquibase-parent-pom version from 0.3.0-SNAPSH…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent-pom</artifactId>
     <name>Liquibase Parent POM</name>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.2.6-SNAPSHOT</version>
     <description>Liquibase Parent POM for all Extensions</description>
     <url>https://github.com/liquibase/liquibase-parent-pom</url>
     <packaging>pom</packaging>
@@ -794,6 +794,12 @@
                                             *;
                                             }
                                             -keep class org.liquibase.** {
+                                            *;
+                                            }
+                                            -keep class software.amazon.** {
+                                            *;
+                                            }
+                                            -keep class io.netty.** {
                                             *;
                                             }
                                         </option>


### PR DESCRIPTION
…OT to 0.2.6-SNAPSHOT for compatibility reasons

feat(pom.xml): add proguard rules to keep classes from software.amazon and io.netty packages to prevent obfuscation errors