### PR TITLE
DAT-16254 Extensions require github package manager configuration to be built locally

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent-pom</artifactId>
     <name>Liquibase Parent POM</name>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
     <description>Liquibase Parent POM for all Extensions</description>
     <url>https://github.com/liquibase/liquibase-parent-pom</url>
     <packaging>pom</packaging>
@@ -544,14 +544,6 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <dependencies>
-                 <dependency>
-                     <groupId>org.liquibase</groupId>
-                     <artifactId>liquibase-extension-testing</artifactId>
-                     <version>${liquibase.version}</version>
-                     <scope>test</scope>
-                 </dependency>
-             </dependencies>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
chore(pom.xml): revert version back to 0.3.3-SNAPSHOT to fix compatibility issues

refactor(pom.xml): remove unnecessary dependency on liquibase-extension-testing in the test scope