### PR TITLE
Don't warn on graal dependencies, swap version to bump patch for new release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent-pom</artifactId>
     <name>Liquibase Parent POM</name>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.5.3-SNAPSHOT</version>
     <description>Liquibase Parent POM for all Extensions</description>
     <url>https://github.com/liquibase/liquibase-parent-pom</url>
     <packaging>pom</packaging>
@@ -780,6 +780,8 @@
                                         <option>-dontwarn org.apache.**</option>
                                         <option>-dontwarn io.netty.**</option>
                                         <option>-dontwarn com.fasterxml.**</option>
+                                        <option>-dontwarn org.graalvm.**</option>
+                                        <option>-dontwarn com.oracle.**</option>
                                     </options>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Update proguard to dontwarn on graal dependencies.