### PR TITLE
DAT-19350 configure test-harness to deploy master-snapshot to GPM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,7 +786,7 @@
                                         <option>-dontwarn com.fasterxml.**</option>
                                         <option>-dontwarn org.graalvm.**</option>
                                         <option>-dontwarn com.oracle.**</option>
-                                        <option>-keepattributes*Annotation*,EnclosingMethod,Signature</option>
+                                        <option>-keepattributes *Annotation*,EnclosingMethod,Signature</option>
                                     </options>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -353,8 +353,7 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportFormat>plain</reportFormat>
                     <systemPropertyVariables>
-                        <com.athaydes.spockframework.report.outputDir>
-                            ${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
+                        <com.athaydes.spockframework.report.outputDir>${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -366,8 +365,7 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportFormat>plain</reportFormat>
                     <systemPropertyVariables>
-                        <com.athaydes.spockframework.report.outputDir>
-                            ${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
+                        <com.athaydes.spockframework.report.outputDir>${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>
@@ -550,8 +548,7 @@
                                     <fileSets>
                                         <fileSet>
                                             <sourceFile>${project.basedir}/pom.xml</sourceFile>
-                                            <destinationFile>
-                                                ${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
+                                            <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
                                         </fileSet>
                                     </fileSets>
                                 </configuration>
@@ -789,8 +786,7 @@
                                         <option>-dontwarn com.fasterxml.**</option>
                                         <option>-dontwarn org.graalvm.**</option>
                                         <option>-dontwarn com.oracle.**</option>
-                                        <option>-keepattributes
-                                            *Annotation*,EnclosingMethod,Signature</option>
+                                        <option>-keepattributes*Annotation*,EnclosingMethod,Signature</option>
                                     </options>
                                 </configuration>
                             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.liquibase</groupId>
     <artifactId>liquibase-parent-pom</artifactId>
     <name>Liquibase Parent POM</name>
-    <version>4.31.0-SNAPSHOT</version>
+    <version>0.5.5-SNAPSHOT</version>
     <description>Liquibase Parent POM for all Extensions</description>
     <url>https://github.com/liquibase/liquibase-parent-pom</url>
     <packaging>pom</packaging>
@@ -227,7 +229,7 @@
                 <artifactId>postgresql</artifactId>
                 <version>${postgresql.version}</version>
                 <scope>test</scope>
-            </dependency> 
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -351,7 +353,8 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportFormat>plain</reportFormat>
                     <systemPropertyVariables>
-                        <com.athaydes.spockframework.report.outputDir>${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
+                        <com.athaydes.spockframework.report.outputDir>
+                            ${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>
@@ -363,7 +366,8 @@
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <reportFormat>plain</reportFormat>
                     <systemPropertyVariables>
-                        <com.athaydes.spockframework.report.outputDir>${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
+                        <com.athaydes.spockframework.report.outputDir>
+                            ${project.build.directory}/spock-reports</com.athaydes.spockframework.report.outputDir>
                     </systemPropertyVariables>
                 </configuration>
                 <executions>
@@ -457,33 +461,35 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                         <groupId>org.codehaus.gmavenplus</groupId>
-                         <artifactId>gmavenplus-plugin</artifactId>
-                         <version>${gmavenplus-plugin.version}</version>
-                         <executions>
-                             <execution>
-                                 <goals>
-                                     <goal>addSources</goal>
-                                     <goal>addTestSources</goal>
-                                     <goal>compile</goal>
-                                     <goal>compileTests</goal>
-                                     <goal>removeStubs</goal>
-                                     <goal>removeTestStubs</goal>
-                                 </goals>
-                                 <!--Runs standard tests and CommandTests which require liquibase-extension-testing-->
-                                 <configuration>
-                                     <testSources>
-                                         <testSource>
-                                             <directory>${project.basedir}/src/test/</directory>
-                                             <includes>
-                                                 <include>**/**.groovy</include>
-                                             </includes>
-                                         </testSource>
-                                     </testSources>
-                                 </configuration>
-                             </execution>
-                         </executions>
-                     </plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <version>${gmavenplus-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>addSources</goal>
+                                    <goal>addTestSources</goal>
+                                    <goal>compile</goal>
+                                    <goal>compileTests</goal>
+                                    <goal>removeStubs</goal>
+                                    <goal>removeTestStubs</goal>
+                                </goals>
+                                <!--Runs
+                                standard tests and CommandTests which require
+                                liquibase-extension-testing-->
+                                <configuration>
+                                    <testSources>
+                                        <testSource>
+                                            <directory>${project.basedir}/src/test/</directory>
+                                            <includes>
+                                                <include>**/**.groovy</include>
+                                            </includes>
+                                        </testSource>
+                                    </testSources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -503,18 +509,18 @@
                         <version>${jacoco-maven-plugin.version}</version>
                         <executions>
                             <execution>
-                              <goals>
-                                <goal>prepare-agent</goal>
-                              </goals>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
                             </execution>
                             <execution>
-                              <id>report</id>
-                              <phase>test</phase>
-                              <goals>
-                                <goal>report</goal>
-                              </goals>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
                             </execution>
-                          </executions>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -544,7 +550,8 @@
                                     <fileSets>
                                         <fileSet>
                                             <sourceFile>${project.basedir}/pom.xml</sourceFile>
-                                            <destinationFile>${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
+                                            <destinationFile>
+                                                ${project.basedir}/target/${project.artifactId}-${project.version}.pom</destinationFile>
                                         </fileSet>
                                     </fileSets>
                                 </configuration>
@@ -609,22 +616,22 @@
                         </executions>
                     </plugin>
                     <plugin>
-                         <groupId>org.codehaus.gmavenplus</groupId>
-                         <artifactId>gmavenplus-plugin</artifactId>
-                         <version>${gmavenplus-plugin.version}</version>
-                         <executions>
-                             <execution>
-                                 <goals>
-                                     <goal>addSources</goal>
-                                     <goal>addTestSources</goal>
-                                     <goal>compile</goal>
-                                     <goal>compileTests</goal>
-                                     <goal>removeStubs</goal>
-                                     <goal>removeTestStubs</goal>
-                                 </goals>
-                             </execution>
-                         </executions>
-                     </plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <version>${gmavenplus-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>addSources</goal>
+                                    <goal>addTestSources</goal>
+                                    <goal>compile</goal>
+                                    <goal>compileTests</goal>
+                                    <goal>removeStubs</goal>
+                                    <goal>removeTestStubs</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -782,7 +789,8 @@
                                         <option>-dontwarn com.fasterxml.**</option>
                                         <option>-dontwarn org.graalvm.**</option>
                                         <option>-dontwarn com.oracle.**</option>
-                                        <option>-keepattributes *Annotation*,EnclosingMethod,Signature</option>
+                                        <option>-keepattributes
+                                            *Annotation*,EnclosingMethod,Signature</option>
                                     </options>
                                 </configuration>
                             </execution>
@@ -790,6 +798,16 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>use-snapshot</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.liquibase</groupId>
+                    <artifactId>test-harness</artifactId>
+                    <version>master-SNAPSHOT</version>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This pull request includes several formatting changes to the `pom.xml` file and the addition of a new Maven profile. The most important changes are listed below:

Formatting improvements:
* Improved readability by reformatting XML tags and attributes to be more consistent and easier to read. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L2-R9) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L354-R357) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L366-R370) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L473-R479) [[5]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L547-R554) [[6]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L785-R793)

New Maven profile:
* Added a new profile `use-snapshot` with a dependency on `test-harness` version `master-SNAPSHOT` to the `pom.xml` file.