### PR TITLE
chore: update AWS credentials configuration and GPG key handling in artifact release workflow

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -4,7 +4,7 @@ permissions:
   contents: write
   id-token: write
   pull-requests: write
-  
+
 on:
   workflow_dispatch:
   pull_request:
@@ -23,8 +23,8 @@ jobs:
         uses: actions/setup-java@v5
         with:
           java-version: 17
-          distribution: 'temurin'
-          cache: 'maven'
+          distribution: "temurin"
+          cache: "maven"
 
       - name: Get Reusable Script Files
         run: |
@@ -78,12 +78,35 @@ jobs:
             echo "Deleted artifact ID: $value"
           done
 
+      - name: Configure AWS credentials for vault access
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.LIQUIBASE_VAULT_OIDC_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Get secrets from vault
+        id: vault-secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,/vault/liquibase
+          parse-json-secrets: true
+
+      - name: Convert escaped newlines and set GPG key
+        run: |
+          {
+            echo "GPG_KEY_CONTENT<<GPG_EOF"
+            printf '%b' "${{ env.GPG_SECRET }}"
+            echo
+            echo "GPG_EOF"
+          } >> $GITHUB_ENV
+
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg_private_key: ${{ secrets.GPG_SECRET }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ env.GPG_KEY_CONTENT }}
+          passphrase: ${{ env.GPG_PASSPHRASE }}
 
       - name: Sign Files for Draft Release
         run: |
@@ -97,4 +120,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ASSET_NAME_PREFIX: "${{ env.artifact_id }}-"
-          ASSET_DIR: ./target      
+          ASSET_DIR: ./target


### PR DESCRIPTION
This pull request updates the `.github/workflows/attach-artifact-release.yml` workflow to improve how GPG secrets are managed and to standardize some configuration values. The changes focus on securely retrieving secrets from AWS Secrets Manager and correctly handling GPG key formatting for signing artifacts.

Improvements to secret management and GPG handling:

* Added steps to configure AWS credentials and retrieve secrets (including the GPG key and passphrase) from AWS Secrets Manager using the `aws-actions/configure-aws-credentials` and `aws-actions/aws-secretsmanager-get-secrets` actions.
* Added a step to convert escaped newlines in the GPG key and set it as an environment variable, ensuring proper formatting when importing the key.
* Updated the GPG import step to use the environment variables populated from AWS Secrets Manager instead of GitHub secrets.

General workflow improvements:

* Standardized the YAML formatting for `distribution` and `cache` values in the Java setup step (changed from single to double quotes for consistency).