### PR TITLE
fix(TECHOPS-53): use converted GPG key content for import

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -105,7 +105,7 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7.0.0
         with:
-          gpg_private_key: ${{ env.GPG_SECRET }}
+          gpg_private_key: ${{ env.GPG_KEY_CONTENT }}
           passphrase: ${{ env.GPG_PASSPHRASE }}
 
       - name: Sign Files for Draft Release


### PR DESCRIPTION
## Summary
- The `Convert escaped newlines and set GPG key` step writes the unescaped key into `GPG_KEY_CONTENT`, but `Import GPG key` was still reading the raw `GPG_SECRET` (with literal `\n`), causing the action to fail with `Misformed armored text`.
- Because the import failed, the `Sign Files for Draft Release` and `Attach Files to Draft Release` steps were skipped, so no artifacts were attached to the draft release.
- Fix: point `gpg_private_key` at `GPG_KEY_CONTENT`, which is what the conversion step is already producing.

Resolves [TECHOPS-53](https://datical.atlassian.net/browse/TECHOPS-53).

## Test plan
- [ ] Trigger the `Attach Artifact to Release` workflow (via merged PR or `workflow_dispatch`) and confirm the `Import GPG key` step succeeds.
- [ ] Confirm `Sign Files for Draft Release` and `Attach Files to Draft Release` run.
- [ ] Verify the draft release has the expected `.pom` and `.asc` assets attached.